### PR TITLE
update store code example in testing docs

### DIFF
--- a/app/scenes/guide/testing/code/store.txt
+++ b/app/scenes/guide/testing/code/store.txt
@@ -1,4 +1,5 @@
-import { resetKeaCache, keaSaga, keaReducer } from 'kea'
+import { resetKeaCache, keaReducer } from 'kea'
+import { keaSaga } from 'kea-saga'
 import { createStore, applyMiddleware, combineReducers, compose } from 'redux'
 import createSagaMiddleware from 'redux-saga'
 


### PR DESCRIPTION
Old example throws `uncaught at check runSaga(storeInterface, saga, ...args): saga argument must be a Generator function!`